### PR TITLE
Fix copies not positioning correctly in-game

### DIFF
--- a/addons/array_modifier/ArrayModifier.gd
+++ b/addons/array_modifier/ArrayModifier.gd
@@ -10,6 +10,7 @@ var _hooks = Dictionary()
 
 func _ready():
 	_adjust_copies()
+	_adjust_position_of_copies()
 
 
 func apply_array_modifier():


### PR DESCRIPTION
Problem:

I position my copies of the meshintance (in the offset settings) but when reloading scene or in-game they back to 0,0,0 

Solution:

call `_adjust_position_of_copies()` in `_ready()` function