### PR TITLE
Fix path nodes disappearing on engine restart

### DIFF
--- a/addons/array_modifier/ArrayModifierPath.gd
+++ b/addons/array_modifier/ArrayModifierPath.gd
@@ -1,7 +1,7 @@
 @tool
 extends Node3D
 
-@export var path: NodePath : set = set_path
+@export var path: Path3D : set = set_path
 @export_range(0, 1, 0.001) var path_offset_start: float : set = set_path_offset_start
 @export var repeat_offset: float : set = set_repeat_offset
 @export var instance_offset: Vector3 = Vector3.ZERO
@@ -9,9 +9,6 @@ extends Node3D
 @export var repeat_count: int = 1 : set = set_repeat_count
 
 var _hooks = Dictionary()
-# Path3D node
-var _path_node = null
-var _path_length = 0
 
 
 func _ready():
@@ -19,12 +16,13 @@ func _ready():
 
 
 func _get_copy_position_rotation(instance_number):
+	var path_length = path.curve.get_baked_length()
 	var position = path_offset_start + instance_number * repeat_offset 
-	var absolute_offset = fmod(_path_length * position, _path_length)
+	var absolute_offset = fmod(path_length * position, path_length)
 	var offset_1 = max(absolute_offset - 0.01, 0)
-	var offset_2 = min(absolute_offset + 0.01, _path_length)
-	var p1 = _path_node.curve.sample_baked(offset_1, true)
-	var p2 = _path_node.curve.sample_baked(offset_2, true)
+	var offset_2 = min(absolute_offset + 0.01, path_length)
+	var p1 = path.curve.sample_baked(offset_1, true)
+	var p2 = path.curve.sample_baked(offset_2, true)
 	var newpos = p1 + ((p2 - p1) / 2.0)
 
 	return [newpos, p2]
@@ -34,16 +32,9 @@ func apply_array_modifier():
 	Engine.get_singleton("undo_redo").apply_array_modifier.call_deferred(self)
 
 
-func set_path(value):
-	if get_node(value) is Path3D:
-		_path_node = get_node(value)
-		_path_length = _path_node.curve.get_baked_length()
-		path = value
-		refresh_duplicates()
-	else:
-		printerr("Selected node is not a Path3D instance")
-		_path_node = null
-		path = NodePath()
+func set_path(value: Path3D):
+	path = value
+	refresh_duplicates()
 
 
 func set_path_offset_start(value):
@@ -68,7 +59,7 @@ func set_repeat_offset(value):
 
 
 func refresh_duplicates():
-	if _path_node == null:
+	if not path:
 		return
 	
 	# Clean up existing hooks
@@ -116,7 +107,7 @@ func refresh_duplicates():
 
 
 func _adjust_position_of_duplicates():
-	if _path_node == null:
+	if not path:
 		return
 	
 	for orig_child in get_children():

--- a/example/ExamplePath.tscn
+++ b/example/ExamplePath.tscn
@@ -19,14 +19,14 @@ size = Vector2(100, 100)
 
 [node name="ExamplePath" type="Node3D"]
 
-[node name="ArrayModifierPath" type="Node3D" parent="."]
+[node name="ArrayModifierPath" type="Node3D" parent="." node_paths=PackedStringArray("path")]
 script = ExtResource("1")
 path = NodePath("../Path3D")
 repeat_offset = 0.1
 repeat_count = 10
 
 [node name="Model" type="MeshInstance3D" parent="ArrayModifierPath"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5, 0, 0)
+transform = Transform3D(0.999938, 0, -0.0111179, 0, 1, 0, 0.0111179, 0, 0.999938, -4.99997, 0, -0.00287338)
 material_override = SubResource("1")
 mesh = ExtResource("2")
 

--- a/example/ExamplePath2D.tscn
+++ b/example/ExamplePath2D.tscn
@@ -11,14 +11,15 @@ point_count = 6
 
 [node name="ExamplePath2D" type="Node2D"]
 
-[node name="ArrayModifierPath2D" type="Node2D" parent="."]
+[node name="ArrayModifierPath2D" type="Node2D" parent="." node_paths=PackedStringArray("path")]
 script = ExtResource("1")
+path = NodePath("../Path2D")
 repeat_offset = 0.2
 repeat_count = 5
 
 [node name="Sprite2D" type="Sprite2D" parent="ArrayModifierPath2D"]
-position = Vector2(86.5713, 153.323)
-rotation = 0.987017
+position = Vector2(86.571, 153.323)
+rotation = -2.00194
 texture = ExtResource("2")
 
 [node name="Path2D" type="Path2D" parent="."]


### PR DESCRIPTION
ArrayModifierPath and ArrayModifierPath2D duplicate nodes along a path. That path is stored as a field in the modifier. When the engine is restarted, the value disappears from the inspector, forcing users to set it manually again. Until the value is set, the duplicated nodes are not created.

This commit fixes the issue, and also replaces old NodePath export with the new syntax.